### PR TITLE
Allow curlOptions to be stored in the handle

### DIFF
--- a/R/handle.r
+++ b/R/handle.r
@@ -7,6 +7,8 @@
 #' @param url full url to site
 #' @param cookies if \code{TRUE} (the default), maintain cookies across
 #'   requests.
+#' @param ... RCurl options to be stored in the handle. See \code{\link{config}}
+#'   for more information about those options.
 #' @export
 #' @examples
 #' handle("http://google.com")

--- a/man/handle.Rd
+++ b/man/handle.Rd
@@ -2,13 +2,17 @@
 \alias{handle}
 \title{Create a handle tied to a particular host.}
 \usage{
-  handle(url, cookies = TRUE)
+  handle(url, cookies = TRUE, ...)
 }
 \arguments{
   \item{url}{full url to site}
 
   \item{cookies}{if \code{TRUE} (the default), maintain
   cookies across requests.}
+
+  \item{...}{RCurl options to be stored in the handle. See
+  \code{\link{config}} for more information about those
+  options.}
 }
 \description{
   This handle preserves settings and cookies across


### PR DESCRIPTION
In particular, this allows to store authentication in the handle itself.
