### PR TITLE
Stop RJSONIO from simplifying content by default.

### DIFF
--- a/R/content-parse.r
+++ b/R/content-parse.r
@@ -34,13 +34,12 @@ parse_auto <- function(content, type = NULL, encoding = NULL, ...) {
 parsers <- new.env(parent = emptyenv())
 
 # http://www.ietf.org/rfc/rfc4627.txt - section 3. (encoding)
-parsers$`application/json` <- function(x, ...) {
-  args <- list(...)
-  if (!("simplifyWithNames" %in% args)) {
-    args$simplifyWithNames = FALSE
-  }
-  do.call(RJSONIO::fromJSON, c(parse_text(x, encoding = "UTF-8"), args))
+parsers$`application/json` <- function(x, simplifyWithNames = FALSE, ...) {
+  RJSONIO::fromJSON(parse_text(x, encoding = "UTF-8"),
+                    simplifyWithNames = simplifyWithNames,
+                    ...)
 }
+
 parsers$`application/x-www-form-urlencoded` <- function(x) {
   parse_query(parse_text(x, encoding = "UTF-8"))
 }

--- a/inst/tests/test-request.r
+++ b/inst/tests/test-request.r
@@ -33,6 +33,3 @@ test_that("headers returned as expected", {
   expect_equal(round_trip(a = "a + b")$a, "a + b")
 
 })
-
-
-

--- a/inst/tests/test-response.r
+++ b/inst/tests/test-response.r
@@ -1,0 +1,15 @@
+context("Response")
+
+test_that("application/json responses parsed as lists", {
+  test_user_agent <- function(user_agent = NULL) {
+    response <- GET("http://httpbin.org/user-agent",
+                    add_headers("user-agent" = user_agent))
+
+    expect_equal(response$status, 200)
+    expected_reply = list("user-agent" = user_agent)
+    expect_equal(expected_reply, content(response))
+  }
+
+  test_user_agent()
+  test_user_agent("gunicorn-client/0.1")
+})


### PR DESCRIPTION
I noticed tests were failing when `content$*` was a vector instead of a list; it looks like RJSONIO simplifies by default. I've wired in a flag that will override this unless the user has requested otherwise.

It occurs to me now that I grepped for `fromJSON`, but not `toJSON`. The latter seems safe enough? Let me know if you want me to dig more.
