### PR TITLE
Allow OAuth authentication dance with no local webserver

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,6 +48,7 @@ Collate:
     'utils.r'
     'oauth-app.r'
     'oauth-endpoint.r'
+    'oauth-exchanger.r'
     'oauth-listener.r'
     'oauth-signature.r'
     'oauth-token.r'

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,9 @@ httr 0.2.99
 
 * Switched to RJSONIO from rjson. No longer loads onto search path.
 
+* Add support for handling the OAuth2 dance without running a local webserver.
+  Contributed by Craig Citro. (#33)
+
 httr 0.2
 -----------
 

--- a/R/content.r
+++ b/R/content.r
@@ -4,7 +4,7 @@
 #' as a raw object (\code{as = "raw"}), as a character vector,
 #' (\code{as = "text"}), and as parsed into an R object where possible,
 #' (\code{as = "parsed"}). If \code{as} is not specified, \code{content}
-#' does it's best to guess which output is most appropriate.
+#' does its best to guess which output is most appropriate.
 #'
 #' \code{content} currently knows about the following mime types:
 #' \itemize{
@@ -15,7 +15,7 @@
 #'  \item \code{image/jpeg}: \code{\link[jpeg]{readJPEG}}
 #'  \item \code{image/png}: \code{\link[png]{readPNG}}
 #' }
-#' You can add new parsers by adding appropriately functions to
+#' You can add new parsers by adding appropriate functions to
 #' \code{httr:::parsers}.
 #'
 #' @param x request object

--- a/R/oauth-exchanger.r
+++ b/R/oauth-exchanger.r
@@ -1,0 +1,23 @@
+#' Walk the user through the OAuth2 dance without a local webserver.
+#'
+#' This performs a similar function to \code{\link{oauth-listener}},
+#' but without trying do open a browser or start a local webserver.
+#' This manual process can be useful in situations where the user is
+#' remotely accessing the machine outside a browser (say via ssh) or
+#' when it's not possible to successfully receive a callback (such as
+#' when behind a firewall).
+#'
+#' This function should generally not be called directly by the user.
+#'
+#' @param request_url the url to provide to the user
+#' @export
+#' @keywords internal
+oauth_exchanger <- function(request_url) {
+  message("Please point your browser to the following url: ")
+  message("")
+  message("  ", request_url)
+  message("")
+  authorization_code <- str_trim(readline("Enter authorization code: "))
+  info <- list(code = authorization_code)
+  info
+}


### PR DESCRIPTION
I'd like to be able to do the OAuth2 dance with no local webserver at all, i.e. by manually copy-pasting a URL and then an authorization code. This is clearly less exciting as a user experience, but is sometimes a necessity (I often find myself doing the auth dance on a machine which isn't visible to the outside world, or only has SSH access). 

I've actually got a version of this I've been using locally, and I'll submit a pull request shortly. In particular, I added an extra `use_local_webserver` argument to `oauth2.0_token`, though I'm happy to thread that out as far as is reasonable. I'm also happy for someone to come up with a better name for the flag.

This is the same request that was mentioned in #31, but is not quite the same as the solution proposed by #32, unless httpuv is cleverer than I think. ;)
