### PR TITLE
Fix some tests.

### DIFF
--- a/inst/tests/test-request.r
+++ b/inst/tests/test-request.r
@@ -16,9 +16,9 @@ test_that("status converted to errors", {
   s500 <- GET("http://httpbin.org/status/500")
 
   expect_equal(stop_for_status(s200), NULL)
-  expect_error(stop_for_status(s300), c("300", "redirect"))
-  expect_error(stop_for_status(s404), c("404", "client"))
-  expect_error(stop_for_status(s500), c("500", "server"))
+  expect_error(stop_for_status(s300), c("redirection.*\\(300\\)"))
+  expect_error(stop_for_status(s404), c("client.*\\(404\\)"))
+  expect_error(stop_for_status(s500), c("server.*\\(500\\)"))
 })
 
 test_that("headers returned as expected", {


### PR DESCRIPTION
These tests previously relied on testthat quietly ignoring additional entries
in the `regexp` for `expect_error`; the version on github checks that, so
these tests are now failing. I fixed them by making the regexps a little
uglier; feel free to tell me to think harder about it. ;)
