### PR TITLE
Add support for `fragment` in `parse_url` and `build_url`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,9 @@ httr 0.2.99
   httpd server). This makes the dance work in Rstudio, and also seems a little
   faster. (#32, thanks to @jdeboer)
 
+* Add support for `fragment` in url building/parsing. Contributed by
+  Craig Citro. (#70)
+
 httr 0.2
 -----------
 

--- a/inst/tests/test-url.r
+++ b/inst/tests/test-url.r
@@ -8,6 +8,7 @@ test_that("parse_url works as expected", {
     "http://google.com/path?a=1&b=2",
     "http://google.com/path;param?a=1&b=2",
     "http://google.com:80/path;param?a=1&b=2",
+    "http://google.com:80/path;param?a=1&b=2#frag",
     "http://user@google.com:80/path;param?a=1&b=2",
     "http://user:pass@google.com:80/path;param?a=1&b=2",
     "svn+ssh://my.svn.server/repo/trunk"
@@ -31,4 +32,12 @@ test_that("query strings escaped and unescaped correctly", {
   parsed <- parse_url(url)
   expect_equal(parsed$query, list("x y" = "a b"))
   expect_equal(build_url(parsed), url)
+})
+
+test_that("password and no username is an error", {
+  url <- "http://www.example.com/"
+  parsed <- parse_url(url)
+  expect_equal(build_url(parsed), url)
+  parsed$password <- "secret"
+  expect_error(build_url(parsed), "password without username")
 })

--- a/man/modify_url.Rd
+++ b/man/modify_url.Rd
@@ -3,13 +3,13 @@
 \title{Modify a url.}
 \usage{
 modify_url(url, scheme = NULL, hostname = NULL, port = NULL,
-  path = NULL, query = NULL, params = NULL, username = NULL,
-  password = NULL)
+  path = NULL, query = NULL, params = NULL, fragment = NULL,
+  username = NULL, password = NULL)
 }
 \arguments{
   \item{url}{the url to modify}
 
-  \item{scheme,hostname,port,path,query,params,username,password}{components
+  \item{scheme,hostname,port,path,query,params,fragment,username,password}{components
   of the url to change}
 }
 \description{


### PR DESCRIPTION
Any opposition to adding support for the [fragment](http://tools.ietf.org/html/rfc1808.html#section-2.4.1)? It looks like `parse_url` already [grabs it](https://github.com/hadley/httr/blob/a9492849d44198c53148b1d8681bb2869c51b0e8/R/url.r#L43).
