### PR TITLE
Handle case where listener receives an empty string

### DIFF
--- a/R/oauth-listener.r
+++ b/R/oauth-listener.r
@@ -22,7 +22,9 @@ oauth_listener <- function(request_url) {
 
   info <- NULL
   listen <- function(env) {
-    info <<- parse_query(gsub("^\\?", "", env$QUERY_STRING))
+    if ((is.character(env$QUERY_STRING)) && (env$QUERY_STRING != "")) {
+      info <<- parse_query(gsub("^\\?", "", env$QUERY_STRING))
+    }
     list(
       status = 200L,
       headers = list("Content-type" = "text/plain"),


### PR DESCRIPTION
Take 2.

This handles the problem I was describing in email the other day. I'm seeing the listener function receive an empty QUERY_STRING at times which blows things up downstream.
