### PR TITLE
Move needed packages from Suggests to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,14 +15,14 @@ Imports:
     stringr (>= 0.6.1),
     digest,
     tools,
-    methods
-Suggests:
+    methods,
     jsonlite,
     XML,
-    testthat (>= 0.8.0),
     png,
     jpeg,
-    httpuv,
+    httpuv
+Suggests:
+    testthat (>= 0.8.0),
     knitr
 VignetteBuilder: knitr
 Roxygen: list(wrap = FALSE)


### PR DESCRIPTION
Some packages are used outside of examples, tests and vignettes. These packages should be listed under Imports and not Suggests.
http://cran.r-project.org/doc/manuals/R-exts.html#Package-Dependencies
