### PR TITLE
Fixed cookie variable format issue

### DIFF
--- a/R/cookies.r
+++ b/R/cookies.r
@@ -17,7 +17,7 @@ set_cookies <- function(..., .cookies = character(0)) {
 
   cookies_str <- vapply(cookies, RCurl::curlEscape, FUN.VALUE = character(1))
 
-  cookie <- paste0(names(cookies), cookies_str, sep = "=", collapse = ";")
+  cookie <- paste(names(cookies), cookies_str, sep = "=", collapse = ";")
 
   config(cookie = cookie)
 }


### PR DESCRIPTION
Ref: http://stackoverflow.com/a/25381506/1457051

the `paste0` was causing `a = "1"` to be `a1=` instead of `a=1`
