### PR TITLE
Fix url_ok bug, status codes are integers

### DIFF
--- a/R/response-status.r
+++ b/R/response-status.r
@@ -152,7 +152,7 @@ http_statuses <- c(
 #' url_ok("http://httpbin.org/status/201")
 url_ok <- function(...) {
   x <- HEAD(...)
-  identical(status_code(x), 200)
+  identical(status_code(x), 200L)
 }
 
 #' Check for an http success status.

--- a/tests/testthat/test-response.r
+++ b/tests/testthat/test-response.r
@@ -13,3 +13,12 @@ test_that("application/json responses parsed as lists", {
   test_user_agent()
   test_user_agent("gunicorn-client/0.1")
 })
+
+test_that("url_ok works as expected", {
+
+  expect_true(url_ok("http://httpbin.org/status/200"))
+  expect_false(url_ok("http://httpbin.org/status/300"))
+  expect_false(url_ok("http://httpbin.org/status/404"))
+  expect_false(url_ok("http://httpbin.org/status/500"))
+
+})


### PR DESCRIPTION
This happens:

``` r
url_ok("http://httpbin.org/status/200")
# [1] FALSE
```

Because status codes are converted to integers here:
https://github.com/hadley/httr/blob/26d986de55c2142e91921a1fd94ad01311e6ebf0/R/perform.R#L66
But the test is against  a real number:
https://github.com/hadley/httr/blob/26d986de55c2142e91921a1fd94ad01311e6ebf0/R/response-status.r#L155

Also added some simple tests for this.
