### PR TITLE
clarify required GitHub application information

### DIFF
--- a/demo/oauth2-github.r
+++ b/demo/oauth2-github.r
@@ -4,11 +4,12 @@ library(httr)
 #    http://developer.github.com/v3/oauth/
 oauth_endpoints("github")
 
-# 2. Register an application at https://github.com/settings/applications
-#    Insert your values below - if secret is omitted, it will look it up in
-#    the GITHUB_CONSUMER_SECRET environmental variable.
+# 2. Register an application at https://github.com/settings/applications;
+#    Use any URL you would like for the homepage URL (http://github.com is fine)
+#    and http://localhost:1410 as the callback url
 #
-#    Use http://localhost:1410 as the callback url
+#    Insert your client ID and secret below - if secret is omitted, it will
+#    look it up in the GITHUB_CONSUMER_SECRET environmental variable.
 myapp <- oauth_app("github", "56b637a5baffac62cad9")
 
 # 3. Get OAuth credentials


### PR DESCRIPTION
Make it clear that the application URL can be anything, and that
the required credentials are the client ID and secret. Closes #131.
