### PR TITLE
Add URL encoding to handle-url

### DIFF
--- a/R/handle-url.r
+++ b/R/handle-url.r
@@ -12,6 +12,9 @@ handle_url <- function(handle = NULL, url = NULL, ...) {
     old <- parse_url(url)
     url <- build_url(modifyList(old, new))
   }
+  
+  #Regardless of components, encode
+  url <- URLencode(url)
 
   list(handle = handle, url = url)
 }


### PR DESCRIPTION
httr doesn't, that I can see, include automatic URL encoding. 9 times out of 10 this is fine, but I can't think of a good reason why the library can't handle the 10th case, too, instead of pushing that on to the reuser.

(If there is a good argument for not encoding by default that I'm just unaware of, obviously just close the request ;p)
