### PR TITLE
Encoding change for JSON bodies

### DIFF
--- a/R/body.R
+++ b/R/body.R
@@ -1,4 +1,4 @@
-body_config <- function(body = NULL, encode = "form")  {
+body_config <- function(body = NULL, encode = "form", type = NULL)  {
   # Post without body
   if (is.null(body)) return(body_raw(raw()))
 
@@ -7,7 +7,7 @@ body_config <- function(body = NULL, encode = "form")  {
 
   # For character/raw, send raw bytes
   if (is.character(body) || is.raw(body)) {
-    return(body_raw(body))
+    return(body_raw(body, type = type))
   }
 
   # Send single file lazily

--- a/R/http-post.r
+++ b/R/http-post.r
@@ -51,5 +51,14 @@ POST <- function(url = NULL, config = list(), ..., body = NULL,
   hu <- handle_url(handle, url, ...)
   config <- make_config(config, ...)
 
-  make_request("post", hu$handle, hu$url, config, body_config(body, encode))
+  content_type <- NULL
+  content_type_key <- grep("content-type", names(config$httpheader),
+                           ignore.case = TRUE, value = TRUE)
+  # TODO(craigcitro): Deal with the case of more than one matching
+  # key.
+  if (length(content_type_key) > 0) {
+    content_type <- config$httpheader[[content_type_key]]
+  }
+  make_request("post", hu$handle, hu$url, config,
+               body_config(body, encode, type = content_type))
 }

--- a/tests/testthat/test-body.r
+++ b/tests/testthat/test-body.r
@@ -25,6 +25,14 @@ test_that("string/raw in body gives same string in data element", {
   expect_equal(out$data, "test")
 })
 
+test_that("string/raw in body doesn't lose content type", {
+  body <- charToRaw("test")
+  content_type <- "application/awesome"
+  response <- content(POST("http://httpbin.org/post", body = body,
+                           add_headers("Content-type" = content_type)))
+  expect_equal(response$headers$`Content-Type`, content_type)
+})
+
 test_that("named list matches form results (encode = 'form')", {
   out <- round_trip(body = list(a = 1, b = 2), encode = "form")
   expect_equal(out$form$a, "1")


### PR DESCRIPTION
Between 0.4 and 0.5, something has changed about the way JSON bodies get encoded -- a list like 

```
ls <- list(f = "hi") 
```

was previously encoded as 

```
{"f": "hi"} 
```

but is now being encoded as 

```
{"f": ["hi"]}
```

this of course wreaks havoc on any API that doesn't differentiate a string and a list with one string. in particular, it's causing failures in `bigrquery` as discovered by @deflaux.

i'm still digging to figure out whether the change was on the `httr` side or the `jsonlite` side.
