### PR TITLE
modify_url fix for paths without trailing slash

### DIFF
--- a/R/url.r
+++ b/R/url.r
@@ -43,7 +43,7 @@ parse_url <- function(url) {
 
   fragment <- pull_off("#(.*)$")
   scheme <- pull_off("^([[:alpha:]+.-]+):")
-  netloc <- pull_off("^//([^/]*)/?")
+  netloc <- pull_off("^//([^/?]*)/?")
 
   if (!is.null(netloc)) {
 

--- a/tests/testthat/test-url.r
+++ b/tests/testthat/test-url.r
@@ -61,3 +61,9 @@ test_that("build_url drops null query", {
   expect_equal(url, "http://google.com/?a=1")
 
 })
+
+test_that("parse_url pulls off domain correctly given query without trailing '/'", {
+   url <- modify_url('http://google.com?a=1', query = list(b = 2)) 
+   expect_equal(url, "http://google.com/?a=1&b=2")
+})
+


### PR DESCRIPTION
Before:

``` R
modify_url('http://google.com?a=1', query = list(b = 2))
# "http://google.com?a=1/?b=2"
```

After:

``` R
modify_url('http://google.com?a=1', query = list(b = 2))
# "http://google.com/?a=1&b=2"
```
