### PR TITLE
Default to the "oob" flow if httpuv isn't installed.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,9 @@
 
 * Update `cacert.pem` to Thu Sep 4 06:31:22 2014 (#154).
 
+* Default to out-of-band credential exchange when `httpuv` isn't installed.
+  (#168)
+
 ## Deprecated and deleted functions
 
 * `new_token()` has been removed - this was always an internal function

--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -48,12 +48,18 @@ init_oauth1.0 <- function(endpoint, app, permission = NULL,
 #' @param scope a character vector of scopes to request.
 #' @param use_oob if FALSE, use a local webserver for the OAuth dance.
 #'     Otherwise, provide a URL to the user and prompt for a validation
-#'     code. Defaults to the of the \code{"httr_oob_default"} default.
+#'     code. Defaults to the of the \code{"httr_oob_default"} default,
+#'     or \code{TRUE} if \code{httpuv} is not installed.
 #' @export
 #' @keywords internal
 init_oauth2.0 <- function(endpoint, app, scope = NULL, type = NULL,
                           use_oob = getOption("httr_oob_default"),
                           is_interactive = interactive()) {
+  if (!use_oob && !is_installed("httpuv")) {
+    message("httpuv not installed, defaulting to out-of-band authentication")
+    use_oob <- TRUE
+  }
+
   if (isTRUE(use_oob)) {
     stopifnot(interactive())
     redirect_uri <- "urn:ietf:wg:oauth:2.0:oob"

--- a/man/init_oauth2.0.Rd
+++ b/man/init_oauth2.0.Rd
@@ -18,7 +18,8 @@ init_oauth2.0(endpoint, app, scope = NULL, type = NULL,
 
 \item{use_oob}{if FALSE, use a local webserver for the OAuth dance.
 Otherwise, provide a URL to the user and prompt for a validation
-code. Defaults to the of the \code{"httr_oob_default"} default.}
+code. Defaults to the of the \code{"httr_oob_default"} default,
+or \code{TRUE} if \code{httpuv} is not installed.}
 
 \item{is_interactive}{Is the current environment interactive?}
 }

--- a/man/oauth2.0_token.Rd
+++ b/man/oauth2.0_token.Rd
@@ -19,7 +19,8 @@ oauth2.0_token(endpoint, app, scope = NULL, type = NULL,
 
 \item{use_oob}{if FALSE, use a local webserver for the OAuth dance.
 Otherwise, provide a URL to the user and prompt for a validation
-code. Defaults to the of the \code{"httr_oob_default"} default.}
+code. Defaults to the of the \code{"httr_oob_default"} default,
+or \code{TRUE} if \code{httpuv} is not installed.}
 
 \item{as_header}{If \code{TRUE}, the default, sends oauth in bearer header.
 If \code{FALSE}, adds as parameter to url.}


### PR DESCRIPTION
This modifies the logic in oauth token fetching to default to using the `oob`
flow (i.e. provide a URL and ask the user to copy-paste a code) whenever
`httpuv` isn't available to use locally.

PTAL @hadley @deflaux
