### PR TITLE
small change in regex code to fix header parsing

### DIFF
--- a/R/perform.R
+++ b/R/perform.R
@@ -76,7 +76,7 @@ parse_single_header <- function(lines) {
 
   # Parse headers into name-value pairs
   header_lines <- lines[lines != ""][-1]
-  pos <- regexec("^(.*?):\\s*(.*?)$", header_lines)
+  pos <- regexec("^(.*?):\\s(.*?)$", header_lines)
   pieces <- regmatches(header_lines, pos)
 
   n <- vapply(pieces, length, integer(1))


### PR DESCRIPTION
@hadley recently noticed that with `v0.6` some headers aren't parsed correctly. In a pkg I maintain we get the links for full text content of articles for text mining purposes in the `link` header element to 

e.g., Using the Crossref API described at http://tdmsupport.crossref.org/full-text-uris-technical-details/

``` r
url <- "http://dx.doi.org/10.5555/515151"
headers <- add_headers(Accept = "application/vnd.crossref.unixsd+xml")
res <- HEAD(url, headers)
res$headers
```

``` r
$`access-control-allow-headers`
[1] "X-Requested-With"

$`access-control-allow-origin`
[1] "*"

$...
[1] "//id.crossref.org/schema/person\""

$`content-type`
[1] "application/vnd.crossref.unixsd+xml"

$`content-length`
[1] "0"

$server
[1] "http-kit"

$`date: sun, 14 dec 2014 03:52`
[1] "02 GMT"
```

Notice how `date` and the field that is `...` (which should be named `link`, see below) aren't parsed correctly. 

This pull request gives 

``` r
url <- "http://dx.doi.org/10.5555/515151"
headers <- add_headers(Accept = "application/vnd.crossref.unixsd+xml")
res <- HEAD(url, headers)
res$headers
```

``` r
$`access-control-allow-headers`
[1] "X-Requested-With"

$`access-control-allow-origin`
[1] "*"

$link
[1] "<http://annalsofpsychoceramics.labs.crossref.org/fulltext/10.5555/515151.pdf>; rel=\"http://id.crossref.org/schema/fulltext\"; type=\"application/pdf\"; version=\"vor\", <http://annalsofpsychoceramics.labs.crossref.org/fulltext/10.5555/515151.xml>; rel=\"http://id.crossref.org/schema/fulltext\"; type=\"application/xml\"; version=\"vor\", <http://www.crossref.org/license>; rel=\"http://id.crossref.org/schema/license\"; version=\"vor\", <http://creativecommons.org/licenses/by/3.0/deed.en_US>; rel=\"http://id.crossref.org/schema/license\"; version=\"vor\", <http://orcid.org/0000-0002-1825-0097>; rel=\"http://id.crossref.org/schema/person\""

$`content-type`
[1] "application/vnd.crossref.unixsd+xml"

$`content-length`
[1] "0"

$server
[1] "http-kit"

$date
[1] "Sun, 14 Dec 2014 03:51:18 GMT"
```

Tests all run fine with this change, though I'm sure you'll know better if this will lead to problems
