### PR TITLE
close post connections on completion

### DIFF
--- a/R/body.R
+++ b/R/body.R
@@ -13,14 +13,18 @@ body_config <- function(body = NULL, encode = "form", type = NULL)  {
   # Send single file lazily
   if (inherits(body, "FileUploadInfo")) {
     con <- file(body$filename, "rb")
-    # FIXME: also need to close when done
     mime_type <- body$contentType %||%
       mime::guess_type(body$filename, empty = NULL)
     size <- file.info(body$filename)$size
 
     return(body_httr(
       post = TRUE,
-      readfunction = function(nbytes, ...) readBin(con, "raw", nbytes),
+      readfunction = function(nbytes, ...) {
+          bin <- readBin(con, "raw", nbytes)
+          if (!length(bin))
+              close(con)
+          bin
+      },
       postfieldsize = size,
       type = mime_type
     ))


### PR DESCRIPTION
PUT(..., body=upload_file()) leaves an open connection, so PUTing many files exhausts the pool of available connections (cf., comment in original code). This pull request closes the connection when its input is complete; the connection might remain open / in use if an error occurs.