### PR TITLE
Use explicit rather than partial matching

### DIFF
--- a/tests/testthat/test-body.r
+++ b/tests/testthat/test-body.r
@@ -54,7 +54,7 @@ test_that("named list matches form results (encode = 'json')", {
 test_that("file and form vals mixed give form and data elements", {
   out <- round_trip(body = list(y = data_path, a = 1))
   expect_equal(out$form$a, "1")
-  expect_equal(strsplit(out$file$y, "\n")[[1]], data)
+  expect_equal(strsplit(out$files$y, "\n")[[1]], data)
 })
 
 test_that("single file matches contents on disk", {

--- a/tests/testthat/test-config.r
+++ b/tests/testthat/test-config.r
@@ -10,15 +10,15 @@ test_that("basic authentication works", {
   path <- "basic-auth/user/passwd"
 
   r <- GET(path = path, handle = h)
-  expect_equal(r$status, 401)
+  expect_equal(r$status_code, 401)
 
   r <- GET(path = path, handle = h,
     config = authenticate("user", "passwd", "basic"))
-  expect_equal(r$status, 200)
+  expect_equal(r$status_code, 200)
 
   # Authentication shouldn't persist
   r <- GET(path = path, handle = h)
-  expect_equal(r$status, 401)
+  expect_equal(r$status_code, 401)
 })
 
 test_that("digest authentication works", {
@@ -26,11 +26,11 @@ test_that("digest authentication works", {
   path <- "digest-auth/qop/user/passwd"
 
   r <- GET(path = path, handle = h)
-  expect_equal(r$status, 401)
+  expect_equal(r$status_code, 401)
 
   r <- GET(path = path, handle = h,
     config = authenticate("user", "passwd", "digest"))
-  expect_equal(r$status, 200)
+  expect_equal(r$status_code, 200)
 })
 
 test_that("oauth2.0 signing works", {

--- a/tests/testthat/test-request.r
+++ b/tests/testthat/test-request.r
@@ -2,9 +2,9 @@ context("Request")
 
 test_that("status codes returned as expected", {
 
-  expect_equal(GET("http://httpbin.org/status/320")$status, 320)
-  expect_equal(GET("http://httpbin.org/status/404")$status, 404)
-  expect_equal(GET("http://httpbin.org/status/418")$status, 418)
+  expect_equal(GET("http://httpbin.org/status/320")$status_code, 320)
+  expect_equal(GET("http://httpbin.org/status/404")$status_code, 404)
+  expect_equal(GET("http://httpbin.org/status/418")$status_code, 418)
 
 })
 

--- a/tests/testthat/test-response.r
+++ b/tests/testthat/test-response.r
@@ -5,7 +5,7 @@ test_that("application/json responses parsed as lists", {
     response <- GET("http://httpbin.org/user-agent",
                     add_headers("user-agent" = user_agent))
 
-    expect_equal(response$status, 200)
+    expect_equal(response$status_code, 200)
     expected_reply = list("user-agent" = user_agent %||% default_ua())
     expect_equal(expected_reply, content(response))
   }


### PR DESCRIPTION
https://github.com/hadley/httr/commit/e415faf42f1260b59bbe30e8648d4999fe83cbee fixed the partial match in the httr code, but there were a few more places in the tests that were also using partial matching.

found by running the tests with

```r
options(warnPartialMatchAttr = TRUE, warnPartialMatchDollar = TRUE,
        warn = 2)
```