### PR TITLE
Added check for existing cainfo config setting

### DIFF
--- a/R/config.r
+++ b/R/config.r
@@ -196,7 +196,8 @@ default_config <- function() {
     user_agent(default_ua()),
     add_headers(Accept = "application/json, text/xml, application/xml, */*"),
     write_memory(),
-    if (.Platform$OS.type == "windows") config(cainfo = cert),
+    if (.Platform$OS.type == "windows"  &&
+      !("cainfo" %in% names(getOption("httr_config")))) config(cainfo = cert),
     getOption("httr_config")
   )
 }


### PR DESCRIPTION
The current behavior on Windows is to set always reset `cainfo` to the default package file, regardless of whether the user has already specified a value for the parameter.  This update adds a check to verify that `cainfo` has not already been set before setting to the default.

This is a re-submission of #199.