### PR TITLE
rm trailing slash in url (hostname) as redundant.

### DIFF
--- a/vignettes/api-packages.Rmd
+++ b/vignettes/api-packages.Rmd
@@ -30,7 +30,7 @@ We start with functions to execute `GET` and `POST` requests:
 ```{r}
 github_GET <- function(path, ..., pat = github_pat()) {
   auth <- github_auth(pat)
-  req <- GET("https://api.github.com/", path = path, auth, ...)
+  req <- GET("https://api.github.com", path = path, auth, ...)
   github_check(req)
 
   req
@@ -42,7 +42,7 @@ github_POST <- function(path, body, ..., pat = github_pat()) {
   stopifnot(is.list(body))
   body_json <- jsonlite::toJSON(body)
 
-  req <- POST("https://api.github.com/", path = path, body = body_json,
+  req <- POST("https://api.github.com", path = path, body = body_json,
     auth, post, ...)
   github_check(req)
 


### PR DESCRIPTION
https://api.github.com/ --> https://api.github.com

The `hostname` of `url` _itself_ doesn't/?shouldn't actually contain the trailing slash.

### Eg:
```r
library(httr)
slashy <- modify_url("https://api.github.com/",path = 'my-path')
no_slashy <- modify_url("https://api.github.com",path = 'my-path')
identical(slashy, no_slashy)
#> [1] TRUE
```

Or if you should use the `slashy` version I would love an explanation (sorry if it's very obvious).