### PR TITLE
Avoid having to set ip address twice for non-docker server

### DIFF
--- a/R/oauth-listener.r
+++ b/R/oauth-listener.r
@@ -76,12 +76,12 @@ oauth_listener <- function(request_url, is_interactive = interactive()) {
 #' @export
 oauth_callback <- function() {
 	paste0("http://", 
-               Sys.getenv("HTTR_SERVER", "localhost"),
+               Sys.getenv("HTTR_SERVER", "127.0.0.1"),
                ":",
                Sys.getenv("HTTR_SERVER_PORT", "1410"))
 }
 
 listener_endpoint <- function() {
-  list(host = Sys.getenv("HTTR_LOCALHOST", "127.0.0.1"),
-       port = as.integer(Sys.getenv("HTTR_PORT", "1410")))
+  list(host = Sys.getenv("HTTR_LOCALHOST", Sys.getenv("HTTR_LOCALHOST", "127.0.0.1")),
+       port = as.integer(Sys.getenv("HTTR_PORT", Sys.getenv("HTTR_PORT", "1410"))))
 }


### PR DESCRIPTION
As @daattali pointed out to me, we should avoid having remote server users having to set the IP twice (in both `HTTR_LOCALHOST` and `HTTR_SERVER`, while still covering the docker case where the internal IP set up by httpuv differs from the external ip (on docker the internal one is always 0.0.0.0).  

Now any remote sever user only needs to set the IP in `HTTR_SERVER`.  The rocker images will set `HTTR_LOCALHOST` by default, so docker users won't need to realize this is different.  Non-docker users won't have `HTTR_LOCALHOST` set at all, and so the code will default to the same value as `HTTR_SERVER` now, instead of `localhost`, so the whole thing is a bit more streamlined.  

@hadley Sorry for the multiple commits & PRs to get this right!