### PR TITLE
Tests for HTTP verbs

### DIFF
--- a/tests/testthat/test-response.r
+++ b/tests/testthat/test-response.r
@@ -9,6 +9,29 @@ test_that("status codes returned as expected", {
 
 })
 
+test_that("DELETE deletes", {
+  expect_equal(GET("http://httpbin.org/delete")$status_code, 405)
+  expect_equal(DELETE("http://httpbin.org/delete")$status_code, 200)
+})
+
+test_that("POST posts", {
+  expect_equal(GET("http://httpbin.org/post")$status_code, 405)
+  expect_equal(POST("http://httpbin.org/post", body=list(),
+    encode="json")$status_code, 200)  
+})
+
+test_that("PATCH patches", {
+  expect_equal(GET("http://httpbin.org/patch")$status_code, 405)
+  expect_equal(PATCH("http://httpbin.org/patch", body=list(),
+    encode="json")$status_code, 200)  
+})
+
+test_that("PUT puts", {
+  expect_equal(GET("http://httpbin.org/put")$status_code, 405)
+  expect_equal(PUT("http://httpbin.org/put", body=list(),
+    encode="json")$status_code, 200)  
+})
+
 test_that("status converted to errors", {
 
   s200 <- GET("http://httpbin.org/status/200")

--- a/tests/testthat/test-response.r
+++ b/tests/testthat/test-response.r
@@ -16,20 +16,17 @@ test_that("DELETE deletes", {
 
 test_that("POST posts", {
   expect_equal(GET("http://httpbin.org/post")$status_code, 405)
-  expect_equal(POST("http://httpbin.org/post", body=list(),
-    encode="json")$status_code, 200)  
+  expect_equal(POST("http://httpbin.org/post")$status_code, 200)
 })
 
 test_that("PATCH patches", {
   expect_equal(GET("http://httpbin.org/patch")$status_code, 405)
-  expect_equal(PATCH("http://httpbin.org/patch", body=list(),
-    encode="json")$status_code, 200)  
+  expect_equal(PATCH("http://httpbin.org/patch")$status_code, 200)
 })
 
 test_that("PUT puts", {
   expect_equal(GET("http://httpbin.org/put")$status_code, 405)
-  expect_equal(PUT("http://httpbin.org/put", body=list(),
-    encode="json")$status_code, 200)  
+  expect_equal(PUT("http://httpbin.org/put")$status_code, 200)
 })
 
 test_that("status converted to errors", {


### PR DESCRIPTION
https://github.com/hadley/httr/commit/879a048828a56baedccd85a6d69793d3c5b85639 fixes the behavior for DELETE, PATCH, and PUT. These tests confirm the fix. I wrote the tests against the state of `httr` from a few hours ago, and methods other than GET and POST failed:

```
Response : ....1...2.3..............

1. Failure (at test-response.r#14): DELETE deletes -----------------------------
DELETE("http://httpbin.org/delete")$status_code not equal to 200
200 - 405 == -205

2. Failure (at test-response.r#25): PATCH patches ------------------------------
PATCH("http://httpbin.org/patch", body = list(), encode = "json")$status_code not equal to 200
200 - 405 == -205

3. Failure (at test-response.r#31): PUT puts -----------------------------------
PUT("http://httpbin.org/put", body = list(), encode = "json")$status_code not equal to 200
200 - 405 == -205
Error: Test failures
```

After pulling the latest changes, they all pass now.