### PR TITLE
Add support for OAuth 2.0 implicit grant flow

### DIFF
--- a/R/oauth-token.r
+++ b/R/oauth-token.r
@@ -184,15 +184,17 @@ Token1.0 <- R6::R6Class("Token1.0", inherit = Token, list(
 #' @param as_header If \code{TRUE}, the default, sends oauth in bearer header.
 #'   If \code{FALSE}, adds as parameter to url.
 #' @inheritParams oauth1.0_token
+#' @param use_implicit Use an implicit grant type
 #' @return A \code{Token2.0} reference class (RC) object.
 #' @family OAuth
 #' @export
 oauth2.0_token <- function(endpoint, app, scope = NULL, type = NULL,
                            use_oob = getOption("httr_oob_default"),
                            as_header = TRUE,
-                           cache = getOption("httr_oauth_cache")) {
+                           cache = getOption("httr_oauth_cache"),
+                           use_implicit = FALSE) {
   params <- list(scope = scope, type = type, use_oob = use_oob,
-    as_header = as_header)
+    as_header = as_header, use_implicit = use_implicit)
   Token2.0$new(app = app, endpoint = endpoint, params = params,
     cache_path = cache)
 }
@@ -203,7 +205,7 @@ Token2.0 <- R6::R6Class("Token2.0", inherit = Token, list(
   init_credentials = function() {
     self$credentials <- init_oauth2.0(self$endpoint, self$app,
       scope = self$params$scope, type = self$params$type,
-      use_oob = self$params$use_oob)
+      use_oob = self$params$use_oob, use_implicit = self$params$use_implicit)
   },
   can_refresh = function() {
     !is.null(self$credentials$refresh_token)

--- a/inst/client.html
+++ b/inst/client.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>title</title>
+  <script>
+    var hash = window.location.hash.substr(1);
+    if (hash != null) {
+      xhr = new XMLHttpRequest();
+      xhr.open('POST', encodeURI('/'));
+      xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+      xhr.send(encodeURI(hash));
+    }
+  </script>
+  </head>
+  <body>
+    Authentication complete. Please close this page and return to R.
+  </body>
+</html>


### PR DESCRIPTION
The implicit flow (outlined https://tools.ietf.org/html/rfc6749#section-1.3.2) is oauth2 grant that is used for public (e.g. non-confidential clients). This type of client is typically browser based (javascript) applications where the client can not maintain confidentiality. However, this flow may also be useful for applications such as publicly disturbed R packages. 

The implicit flow is less secure then the authorization code flow (see http://tools.ietf.org/html/rfc6749#section-10.16). Also, not all providers implement this type of grant. One important note is that implicit flows do not issue refresh tokens.