### PR TITLE
Small cleanup.

### DIFF
--- a/R/url-query.r
+++ b/R/url-query.r
@@ -20,7 +20,7 @@ compose_query <- function(elements) {
 
   encode <- function(x) {
     if (inherits(x, "AsIs")) return(x)
-    curl::curl_escape(as.character(x))
+    curl::curl_escape(x)
   }
 
   names <- curl::curl_escape(names(elements))

--- a/R/url.r
+++ b/R/url.r
@@ -118,7 +118,7 @@ build_url <- function(url) {
   if (is.list(url$query)) {
     url$query <- compact(url$query)
     names <- curl::curl_escape(names(url$query))
-    values <- curl::curl_escape(as.character(url$query))
+    values <- curl::curl_escape(url$query)
 
     query <- paste0(names, "=", values, collapse = "&")
   } else {


### PR DESCRIPTION
After the fix in jeroenooms/curl#32, we might as well drop these
`as.character` calls, since they're now unnecessary.

PTAL @hadley 