### PR TITLE
build_url collapse path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Support for uploading large binaries by using postfieldsize_large
 
+* `build_url()` now collapses the `path` argument.
+
 # httr 1.0.0
 
 * httr no longer uses the RCurl package. Instead it uses the curl package, 

--- a/R/url.r
+++ b/R/url.r
@@ -107,6 +107,10 @@ build_url <- function(url) {
     port <- NULL
   }
 
+  if (length(url$path) > 1) {
+    url$path <- paste(url$path, collapse = "/")
+  }
+
   path <- url$path
 
   if (!is.null(url$params)) {

--- a/tests/testthat/test-url.r
+++ b/tests/testthat/test-url.r
@@ -56,6 +56,11 @@ test_that("handle_url ignores unnamed arguments", {
   expect_equal(hu$url, "http://google.com")
 })
 
+test_that("build_url collapse path", {
+  url <- modify_url("http://google.com", path = c("one", "two"))
+  expect_equal(url, "http://google.com/one/two")
+})
+
 test_that("build_url drops null query", {
   url <- modify_url("http://google.com", query = list(a = 1, b = NULL))
   expect_equal(url, "http://google.com/?a=1")


### PR DESCRIPTION
Collapse `path` argument if it length more than 1.