### PR TITLE
Fix request_prepare and trimws dependency

### DIFF
--- a/R/request.R
+++ b/R/request.R
@@ -104,7 +104,7 @@ request_prepare <- function(req) {
   # Sign request, if needed
   token <- req$auth_token
   if (!is.null(token))
-    req <- c(req, token$sign(req$method, req$url))
+    req <- c(req, token$sign(req$method, req$url)$config)
 
   req
 }

--- a/R/str.R
+++ b/R/str.R
@@ -1,14 +1,8 @@
 # These are drop in replacements for the stringr:: functions used in httr. They
 # do not retain all functionality from stringr, only that which is used in
 # httr. Notably they are generally not vectorized.
-str_trim <- function(x, which = c("both", "left", "right")) {
-    which <- match.arg(which)
-    mysub <- function(re, x) sub(re, "", x, perl = TRUE)
-    if(which == "left")
-        return(mysub("^[ \t\r\n]+", x))
-    if(which == "right")
-        return(mysub("[ \t\r\n]+$", x))
-    mysub("[ \t\r\n]+$", mysub("^[ \t\r\n]+", x))
+str_trim <- function(x) {
+    gsub("(^\\s+)|(\\s+$)", "", x)
 }
 
 str_split_fixed <- function(string, pattern, n) {

--- a/R/str.R
+++ b/R/str.R
@@ -1,7 +1,15 @@
 # These are drop in replacements for the stringr:: functions used in httr. They
 # do not retain all functionality from stringr, only that which is used in
 # httr. Notably they are generally not vectorized.
-str_trim <- trimws
+str_trim <- function(x, which = c("both", "left", "right")) {
+    which <- match.arg(which)
+    mysub <- function(re, x) sub(re, "", x, perl = TRUE)
+    if(which == "left")
+        return(mysub("^[ \t\r\n]+", x))
+    if(which == "right")
+        return(mysub("[ \t\r\n]+$", x))
+    mysub("[ \t\r\n]+$", mysub("^[ \t\r\n]+", x))
+}
 
 str_split_fixed <- function(string, pattern, n) {
   if (length(string) == 0) return(matrix(character(), nrow = 1, ncol = n))


### PR DESCRIPTION
Update request_prepare so that when the token is signed, then it returns another request object in order to successfully be combined back to the original request. This is in reference to Issue: https://github.com/hadley/httr/issues/291