### PR TITLE
Annotate http status assertion

### DIFF
--- a/R/response-status.r
+++ b/R/response-status.r
@@ -224,16 +224,18 @@ url_ok <- function(x, ...) {
 #' \dontrun{stop_for_status(x)}
 #' warn_for_status(x)
 #' @export
-stop_for_status <- function(x) {
+stop_for_status <- function(x, msg = NULL) {
   if (status_code(x) < 300) return(invisible(x))
-  stop(http_condition(x, "error", call = sys.call(-1)))
+  if (!is.null(msg)) msg <- sprintf("%s failed: (HTTP %d)", msg, status_code(x))
+  stop(http_condition(x, "error", msg, call = sys.call(-1)))
 }
 
 #' @rdname stop_for_status
 #' @export
-warn_for_status <- function(x) {
+warn_for_status <- function(x, msg = NULL) {
   if (status_code(x) < 300) return(invisible(x))
-  warning(http_condition(x, "warning", call = sys.call(-1)))
+  if (!is.null(msg)) msg <- sprintf("%s failed: (HTTP %d)", msg, status_code(x))
+  warning(http_condition(x, "warning", msg, call = sys.call(-1)))
 }
 
 #' Generate a classed http condition.


### PR DESCRIPTION
See https://github.com/hadley/httr/issues/277. Adds option to annotate the `stop_for_status` error message with an assertion. This can be helpful for http client packages to provide more informative error feedback to the user.

```r
req <- GET("https://httpbin.org/status/404")
stop_for_status(req)
## Error: client error: (404) Not Found

# More informative error
stop_for_status(req, "find spreadsheet")
## Error: find spreadsheet failed: (HTTP 404)
```

