### PR TITLE
expose status code for external library future robustness

### DIFF
--- a/R/response-status.r
+++ b/R/response-status.r
@@ -57,6 +57,7 @@ http_status <- function(x) {
   message <- paste(status_type, ": (", status, ") ", status_desc, sep = "")
 
   list(
+    code = status,
     category = status_type,
     reason = status_desc,
     message = message


### PR DESCRIPTION
This exposes the actual HTTP status code so that external libraries (like bigrquery) can rely on that instead of parsing text that is prone to change.