### PR TITLE
Add option to retrieve oauth2.0 token using basic authentication

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,4 +27,4 @@ Suggests:
 VignetteBuilder: knitr
 License: MIT + file LICENSE
 URL: https://github.com/hadley/httr
-RoxygenNote: 5.0.0
+RoxygenNote: 5.0.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,9 @@
 
 * `build_url()` now collapses vector `path` with `/` (#280, @artemklevtsov).
 
+* `oauth2.0_token()` gains a `use_basic_auth` argument which allows you to pick 
+  the type of http authentication used to retrieve the token (#310, @grahamrp).
+
 # httr 1.0.0
 
 * httr no longer uses the RCurl package. Instead it uses the curl package, 

--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -51,11 +51,16 @@ init_oauth1.0 <- function(endpoint, app, permission = NULL,
 #'     code. Defaults to the of the \code{"httr_oob_default"} default,
 #'     or \code{TRUE} if \code{httpuv} is not installed.
 #' @param is_interactive Is the current environment interactive?
+#' @param use_basic_auth if \code{TRUE} use http basic authentication to
+#'     retrieve the token. Some authorization servers require this.
+#'     If \code{FALSE}, the default, retrieve the token by including the
+#'     app key and secret in the request body.
 #' @export
 #' @keywords internal
 init_oauth2.0 <- function(endpoint, app, scope = NULL, type = NULL,
                           use_oob = getOption("httr_oob_default"),
-                          is_interactive = interactive()) {
+                          is_interactive = interactive(),
+                          use_basic_auth = NULL) {
   if (!use_oob && !is_installed("httpuv")) {
     message("httpuv not installed, defaulting to out-of-band authentication")
     use_oob <- TRUE
@@ -85,13 +90,23 @@ init_oauth2.0 <- function(endpoint, app, scope = NULL, type = NULL,
   }
 
   # Use authorisation code to get (temporary) access token
-  req <- POST(endpoint$access, encode = "form",
-    body = list(
-      client_id = app$key,
-      client_secret = app$secret,
-      redirect_uri = redirect_uri,
-      grant_type = "authorization_code",
-      code = code))
+  if (isTRUE(use_basic_auth)){
+    req <- POST(endpoint$access, encode = "form",
+      body = list(
+        client_id = app$key,
+        redirect_uri = redirect_uri,
+        grant_type = "authorization_code",
+        code = code),
+      authenticate(app$key, app$secret, type = "basic"))
+  } else {
+    req <- POST(endpoint$access, encode = "form",
+      body = list(
+        client_id = app$key,
+        client_secret = app$secret,
+        redirect_uri = redirect_uri,
+        grant_type = "authorization_code",
+        code = code))
+  }
 
   stop_for_status(req)
   content(req, type = type)

--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -92,22 +92,18 @@ init_oauth2.0 <- function(endpoint, app, scope = NULL, type = NULL,
   # Use authorisation code to get (temporary) access token
   # Send credentials using HTTP Basic or as parameters in the request body
   # See https://tools.ietf.org/html/rfc6749#section-2.3 (Client Authentication)
+  body <- list(
+    client_id = app$key,
+    redirect_uri = redirect_uri,
+    grant_type = "authorization_code",
+    code = code)
+
   if (isTRUE(use_basic_auth)){
-    req <- POST(endpoint$access, encode = "form",
-      body = list(
-        client_id = app$key,
-        redirect_uri = redirect_uri,
-        grant_type = "authorization_code",
-        code = code),
+    req <- POST(endpoint$access, encode = "form", body = body,
       authenticate(app$key, app$secret, type = "basic"))
   } else {
-    req <- POST(endpoint$access, encode = "form",
-      body = list(
-        client_id = app$key,
-        client_secret = app$secret,
-        redirect_uri = redirect_uri,
-        grant_type = "authorization_code",
-        code = code))
+    body <- c(body, client_secret = app$secret)
+    req <- POST(endpoint$access, encode = "form", body = body)
   }
 
   stop_for_status(req)

--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -60,7 +60,7 @@ init_oauth1.0 <- function(endpoint, app, permission = NULL,
 init_oauth2.0 <- function(endpoint, app, scope = NULL, type = NULL,
                           use_oob = getOption("httr_oob_default"),
                           is_interactive = interactive(),
-                          use_basic_auth = NULL) {
+                          use_basic_auth = FALSE) {
   if (!use_oob && !is_installed("httpuv")) {
     message("httpuv not installed, defaulting to out-of-band authentication")
     use_oob <- TRUE
@@ -90,6 +90,8 @@ init_oauth2.0 <- function(endpoint, app, scope = NULL, type = NULL,
   }
 
   # Use authorisation code to get (temporary) access token
+  # Send credentials using HTTP Basic or as parameters in the request body
+  # See https://tools.ietf.org/html/rfc6749#section-2.3 (Client Authentication)
   if (isTRUE(use_basic_auth)){
     req <- POST(endpoint$access, encode = "form",
       body = list(

--- a/R/oauth-token.r
+++ b/R/oauth-token.r
@@ -181,8 +181,9 @@ Token1.0 <- R6::R6Class("Token1.0", inherit = Token, list(
 #' caching policies used to store credentials across sessions.
 #'
 #' @inheritParams init_oauth2.0
-#' @param as_header If \code{TRUE}, the default, sends oauth in bearer header.
-#'   If \code{FALSE}, adds as parameter to url.
+#' @param as_header If \code{TRUE}, the default, configures the token to add
+#' itself to the bearer header of subsequent requests.
+#' If \code{FALSE}, configures the token to add itself as a url parameter of subsequent requests.
 #' @inheritParams oauth1.0_token
 #' @return A \code{Token2.0} reference class (RC) object.
 #' @family OAuth
@@ -190,9 +191,10 @@ Token1.0 <- R6::R6Class("Token1.0", inherit = Token, list(
 oauth2.0_token <- function(endpoint, app, scope = NULL, type = NULL,
                            use_oob = getOption("httr_oob_default"),
                            as_header = TRUE,
+                           use_basic_auth = FALSE,
                            cache = getOption("httr_oauth_cache")) {
   params <- list(scope = scope, type = type, use_oob = use_oob,
-    as_header = as_header)
+    as_header = as_header, use_basic_auth = use_basic_auth)
   Token2.0$new(app = app, endpoint = endpoint, params = params,
     cache_path = cache)
 }
@@ -203,7 +205,7 @@ Token2.0 <- R6::R6Class("Token2.0", inherit = Token, list(
   init_credentials = function() {
     self$credentials <- init_oauth2.0(self$endpoint, self$app,
       scope = self$params$scope, type = self$params$type,
-      use_oob = self$params$use_oob)
+      use_oob = self$params$use_oob, use_basic_auth = self$params$use_basic_auth)
   },
   can_refresh = function() {
     !is.null(self$credentials$refresh_token)

--- a/R/oauth-token.r
+++ b/R/oauth-token.r
@@ -183,7 +183,7 @@ Token1.0 <- R6::R6Class("Token1.0", inherit = Token, list(
 #' @inheritParams init_oauth2.0
 #' @param as_header If \code{TRUE}, the default, configures the token to add
 #' itself to the bearer header of subsequent requests.
-#' If \code{FALSE}, configures the token to add itself as a url parameter of subsequent requests.
+#'   If \code{FALSE}, configures the token to add itself as a url parameter of subsequent requests.
 #' @inheritParams oauth1.0_token
 #' @return A \code{Token2.0} reference class (RC) object.
 #' @family OAuth

--- a/man/init_oauth2.0.Rd
+++ b/man/init_oauth2.0.Rd
@@ -5,7 +5,8 @@
 \title{Retrieve OAuth 2.0 access token.}
 \usage{
 init_oauth2.0(endpoint, app, scope = NULL, type = NULL,
-  use_oob = getOption("httr_oob_default"), is_interactive = interactive())
+  use_oob = getOption("httr_oob_default"), is_interactive = interactive(),
+  use_basic_auth = NULL)
 }
 \arguments{
 \item{endpoint}{An OAuth endpoint, created by \code{\link{oauth_endpoint}}}
@@ -23,6 +24,11 @@ code. Defaults to the of the \code{"httr_oob_default"} default,
 or \code{TRUE} if \code{httpuv} is not installed.}
 
 \item{is_interactive}{Is the current environment interactive?}
+
+\item{use_basic_auth}{if \code{TRUE} use http basic authentication to
+retrieve the token. Some authorization servers require this.
+If \code{FALSE}, the default, retrieve the token by including the
+app key and secret in the request body.}
 }
 \description{
 See demos for use.

--- a/man/oauth2.0_token.Rd
+++ b/man/oauth2.0_token.Rd
@@ -6,7 +6,7 @@
 \usage{
 oauth2.0_token(endpoint, app, scope = NULL, type = NULL,
   use_oob = getOption("httr_oob_default"), as_header = TRUE,
-  cache = getOption("httr_oauth_cache"))
+  use_basic_auth = FALSE, cache = getOption("httr_oauth_cache"))
 }
 \arguments{
 \item{endpoint}{An OAuth endpoint, created by \code{\link{oauth_endpoint}}}
@@ -23,8 +23,14 @@ Otherwise, provide a URL to the user and prompt for a validation
 code. Defaults to the of the \code{"httr_oob_default"} default,
 or \code{TRUE} if \code{httpuv} is not installed.}
 
-\item{as_header}{If \code{TRUE}, the default, sends oauth in bearer header.
-If \code{FALSE}, adds as parameter to url.}
+\item{as_header}{If \code{TRUE}, the default, configures the token to add
+itself to the bearer header of subsequent requests.
+If \code{FALSE}, configures the token to add itself as a url parameter of subsequent requests.}
+
+\item{use_basic_auth}{if \code{TRUE} use http basic authentication to
+retrieve the token. Some authorization servers require this.
+If \code{FALSE}, the default, retrieve the token by including the
+app key and secret in the request body.}
 
 \item{cache}{A logical value or a string. \code{TRUE} means to cache
 using the default cache file \code{.oauth-httr}, \code{FALSE} means


### PR DESCRIPTION
Regarding issue #288 this adds an option to `oauth2.0_token` so that when the authorization code is exchanged for the token it can be done using http basic authentication, rather than the default method of including the app key and secret in the request body.

From the [OAuth2.0 Framework RFC](https://tools.ietf.org/html/rfc6749) it looks like authorization servers should provide the http basic authentication method as a minimum, and the method of providing the app key/secret in the request body is optional. I see that the github api allows both, but fitbit only allows basic authentication.