### PR TITLE
fix for token service account

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,8 @@
 
 * `build_url()` now collapses vector `path` with `/` (#280, @artemklevtsov).
 
+* Ensure that OAuth token `sign()` returns a `request` (#313, @nathangoulding).
+
 # httr 1.0.0
 
 * httr no longer uses the RCurl package. Instead it uses the curl package, 

--- a/R/oauth-token.r
+++ b/R/oauth-token.r
@@ -290,7 +290,7 @@ TokenServiceAccount <- R6::R6Class("TokenServiceAccount", inherit = Token2.0, li
     config <- add_headers(
       Authorization = paste('Bearer', self$credentials$access_token)
     )
-    list(url = url, config = config)
+    request_build(method = method, url = url, config)
   },
 
   # Never cache

--- a/R/request.R
+++ b/R/request.R
@@ -103,8 +103,11 @@ request_prepare <- function(req) {
 
   # Sign request, if needed
   token <- req$auth_token
-  if (!is.null(token))
-    req <- c(req, token$sign(req$method, req$url))
+  if (!is.null(token)) {
+    signed_req = token$sign(req$method, req$url)
+    stopifnot(is.request(signed_req))
+    req <- c(req, signed_req)
+  }
 
   req
 }

--- a/R/request.R
+++ b/R/request.R
@@ -68,7 +68,6 @@ request_combine <- function(x, y) {
   if (length(x) == 0 && length(y) == 0) return(request())
   if (length(x) == 0) return(y)
   if (length(y) == 0) return(x)
-  if (length(y$config) > 0 && is.request(y$config)) y = y$config
   stopifnot(is.request(x), is.request(y))
 
   request(

--- a/R/request.R
+++ b/R/request.R
@@ -104,7 +104,7 @@ request_prepare <- function(req) {
   # Sign request, if needed
   token <- req$auth_token
   if (!is.null(token)) {
-    signed_req = token$sign(req$method, req$url)
+    signed_req <- token$sign(req$method, req$url)
     stopifnot(is.request(signed_req))
     req <- c(req, signed_req)
   }

--- a/R/request.R
+++ b/R/request.R
@@ -68,6 +68,7 @@ request_combine <- function(x, y) {
   if (length(x) == 0 && length(y) == 0) return(request())
   if (length(x) == 0) return(y)
   if (length(y) == 0) return(x)
+  if (length(y$config) > 0 && is.request(y$config)) y = y$config
   stopifnot(is.request(x), is.request(y))
 
   request(


### PR DESCRIPTION
@hadley This fixes the root cause of the `Error: is.request(y) is not TRUE` that you've been seeing.

It was only breaking when using the service token, and is caused by the `sign` method not returning what `request_combine` is expecting. PTAL.