### PR TITLE
Add use_basic_auth option when refreshing token

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr 1.1.0.9000
 
+* When `use_basic_auth` option is used to obtain a token, token refreshes will now use basic authentication too.
+
 * Suppress unhelpful "No encoding supplied: defaulting to UTF-8." when 
   printing a response (#327).
 

--- a/R/oauth-refresh.R
+++ b/R/oauth-refresh.R
@@ -3,22 +3,30 @@
 # Refreshes the given token, and returns a new credential with a
 # valid access_token. Based on:
 # https://developers.google.com/accounts/docs/OAuth2InstalledApp#refresh
-refresh_oauth2.0 <- function(endpoint, app, credentials, user_params = NULL) {
+refresh_oauth2.0 <- function(endpoint, app, credentials, user_params = NULL,
+                             use_basic_auth = FALSE) {
   if (is.null(credentials$refresh_token)) {
     stop("Refresh token not available", call. = FALSE)
   }
 
   refresh_url <- endpoint$access
-  body <- list(
+  req_params <- list(
       refresh_token = credentials$refresh_token,
       client_id = app$key,
-      client_secret = app$secret,
       grant_type = "refresh_token")
+
   if (! is.null(user_params)) {
-    body <- utils::modifyList(user_params, body);
+    req_params <- utils::modifyList(user_params, req_params)
   }
 
-  response <- POST(refresh_url, body = body, encode = "form")
+  if (isTRUE(use_basic_auth)) {
+    response <- POST(refresh_url, body = req_params, encode = "form",
+      authenticate(app$key, app$secret, type = "basic"))
+  } else {
+    req_params$client_secret <- app$secret
+    response <- POST(refresh_url, body = req_params, encode = "form")
+  }
+
   if (known_oauth2.0_error(response)) {
     warning("Unable to refresh token", call. = FALSE)
     return(NULL)

--- a/R/oauth-token.r
+++ b/R/oauth-token.r
@@ -220,7 +220,7 @@ Token2.0 <- R6::R6Class("Token2.0", inherit = Token, list(
   },
   refresh = function() {
     cred <- refresh_oauth2.0(self$endpoint, self$app,
-        self$credentials, self$params$user_params)
+        self$credentials, self$params$user_params, self$params$use_basic_auth)
     if (is.null(cred)) {
       remove_cached_token(self)
     } else {


### PR DESCRIPTION
The `use_basic_auth` option added in #310 should also be respected when *refreshing* the token.