### PR TITLE
specify arg name for locale; fixes #329

### DIFF
--- a/R/content-parse.r
+++ b/R/content-parse.r
@@ -112,12 +112,12 @@ parsers$`text/csv` <- function(x, type = NULL, encoding = NULL, ...) {
   need_package("readr")
 
   encoding <- guess_encoding(encoding, type)
-  readr::read_csv(x, readr::locale(encoding = encoding), ...)
+  readr::read_csv(x, locale = readr::locale(encoding = encoding), ...)
 }
 
 parsers$`text/tab-separated-values` <- function(x, type = NULL, encoding = NULL, ...) {
   need_package("readr")
 
   encoding <- guess_encoding(encoding, type)
-  readr::read_tsv(x, readr::locale(encoding = encoding), ...)
+  readr::read_tsv(x, locale = readr::locale(encoding = encoding), ...)
 }

--- a/R/content.r
+++ b/R/content.r
@@ -11,8 +11,8 @@
 #' \itemize{
 #'  \item \code{text/html}: \code{\link[XML]{htmlTreeParse}}
 #'  \item \code{text/xml}: \code{\link[XML]{xmlTreeParse}}
-#'  \item \code{text/csv}: \code{\link{read.csv}}
-#'  \item \code{text/tab-separated-values}: \code{\link{read.delim}}
+#'  \item \code{text/csv}: \code{\link[readr]{read_csv}}
+#'  \item \code{text/tab-separated-values}: \code{\link[readr]{read_tsv}}
 #'  \item \code{application/json}: \code{\link[jsonlite]{fromJSON}}
 #'  \item \code{application/x-www-form-urlencoded}: \code{parse_query}
 #'  \item \code{image/jpeg}: \code{\link[jpeg]{readJPEG}}

--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -117,6 +117,6 @@ init_oauth2.0 <- function(endpoint, app, scope = NULL, user_params = NULL,
     req <- POST(endpoint$access, encode = "form", body = req_params)
   }
 
-  stop_for_status(req)
+  stop_for_status(req, task = "get an access token")
   content(req, type = type)
 }

--- a/R/url.r
+++ b/R/url.r
@@ -141,7 +141,7 @@ build_url <- function(url) {
 
 #' Modify a url.
 #'
-#' Modify a url by first parsing and it then replacing components with
+#' Modify a url by first parsing it and then replacing components with
 #' the non-NULL arguments of this function.
 #'
 #' @export

--- a/man/content.Rd
+++ b/man/content.Rd
@@ -49,8 +49,8 @@ does its best to guess which output is most appropriate.
 \itemize{
  \item \code{text/html}: \code{\link[XML]{htmlTreeParse}}
  \item \code{text/xml}: \code{\link[XML]{xmlTreeParse}}
- \item \code{text/csv}: \code{\link{read.csv}}
- \item \code{text/tab-separated-values}: \code{\link{read.delim}}
+ \item \code{text/csv}: \code{\link[readr]{read_csv}}
+ \item \code{text/tab-separated-values}: \code{\link[readr]{read_tsv}}
  \item \code{application/json}: \code{\link[jsonlite]{fromJSON}}
  \item \code{application/x-www-form-urlencoded}: \code{parse_query}
  \item \code{image/jpeg}: \code{\link[jpeg]{readJPEG}}

--- a/man/modify_url.Rd
+++ b/man/modify_url.Rd
@@ -14,7 +14,7 @@ modify_url(url, scheme = NULL, hostname = NULL, port = NULL,
 \item{scheme, hostname, port, path, query, params, fragment, username, password}{components of the url to change}
 }
 \description{
-Modify a url by first parsing and it then replacing components with
+Modify a url by first parsing it and then replacing components with
 the non-NULL arguments of this function.
 }
 


### PR DESCRIPTION
Keeps locale from being interpreted as `col_names`. And some other minor housekeeping.

Before vs. after in my indirect usage:

``` r
## before
africa <- gs_read(gap)
#> Accessing worksheet titled "Africa"
#> No encoding supplied: defaulting to UTF-8.

#>  Error: `col_names` must be TRUE, FALSE or a character vector 

##after
africa <- gs_read(gap)
#> Accessing worksheet titled "Africa"
#> No encoding supplied: defaulting to UTF-8.
```