### PR TITLE
close connection when done reading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr 1.1.0.9000
 
+* Fix in readfunction to close connection when done.
+
 # httr 1.1.0
 
 ## New features

--- a/R/body.R
+++ b/R/body.R
@@ -16,9 +16,13 @@ body_config <- function(body = NULL, encode = "form", type = NULL)  {
       config(
         post = TRUE,
         readfunction = function(nbytes, ...) {
+          if(is.null(con))
+            return(raw())
           bin <- readBin(con, "raw", nbytes)
-          if (!length(bin))
+          if (length(bin) < nbytes){
             close(con)
+            con <<- NULL
+          }
           bin
         },
         postfieldsize_large = size


### PR DESCRIPTION
Bug found by @jennybc. Currently `httr` leaves open lingering connections after uploading a file:

```r
library(httr)
citation <- upload_file(system.file("CITATION"))
req <- POST("http://httpbin.org/post", body = citation)
showConnections()
```

So you get the annoying warning:

```r
rm(req)
gc()
# Warning message:
# closing unused connection 3 (/Library/Frameworks/R.framework/Versions/3.2/Resources/library/base/CITATION) 
```

It looks like there was a subtle change in behavior of libcurl. Old versions keep calling `readfunctions` until it returns 0 bytes. But the recent libcurl assumes we are done once readfunction returns less than the requested data. 