### PR TITLE
Drop leading slash from path

### DIFF
--- a/R/url.r
+++ b/R/url.r
@@ -110,7 +110,7 @@ build_url <- function(url) {
     port <- NULL
   }
 
-  path <- paste(url$path, collapse = "/")
+  path <- paste(gsub("^/", "", url$path), collapse = "/")
 
   if (!is.null(url$params)) {
     params <- paste0(";", url$params)
@@ -160,6 +160,5 @@ modify_url <- function(url, scheme = NULL, hostname = NULL, port = NULL,
 
   build_url(utils::modifyList(old, new))
 }
-
 
 compact <- function(x) Filter(Negate(is.null), x)

--- a/tests/testthat/test-url.r
+++ b/tests/testthat/test-url.r
@@ -61,6 +61,11 @@ test_that("build_url collapse path", {
   expect_equal(url, "http://google.com/one/two")
 })
 
+test_that("build_url drops leading / in path", {
+  url <- modify_url("http://google.com", path = "/one")
+  expect_equal(url, "http://google.com/one")
+})
+
 test_that("build_url drops null query", {
   url <- modify_url("http://google.com", query = list(a = 1, b = NULL))
   expect_equal(url, "http://google.com/?a=1")


### PR DESCRIPTION
Makes it easier to copy/paste from documentation for, e.g., [Google Drive](https://developers.google.com/drive/v3/reference/) and [Github APIs](https://developer.github.com/v3/repos/). Both provide a global url, then paths for each endpoint *with a leading slash*.

Before:

``` r
(url <-
  httr::modify_url("https://api.github.com", path = "/users/hadley/repos"))
#> [1] "https://api.github.com//users/hadley/repos"
x <- httr::GET(url)
status_code(x)
#> [1] 404
```

After:

``` r
(url <-
  httr::modify_url("https://api.github.com", path = "/users/hadley/repos"))
#> [1] "https://api.github.com/users/hadley/repos"
x <- httr::GET(url)
status_code(x)
#> [1] 200
```