### PR TITLE
Change encoding for query part; fixes #335

### DIFF
--- a/R/body.R
+++ b/R/body.R
@@ -40,7 +40,8 @@ body_config <- function(body = NULL, encode = "form", type = NULL)  {
 
   # Deal with three ways to encode: form, multipart & json
   if (encode == "form") {
-    body_raw(compose_query(body), "application/x-www-form-urlencoded")
+    body_raw(compose_query(body, part = "other"),
+             "application/x-www-form-urlencoded")
   } else if (encode == "json") {
     body_raw(jsonlite::toJSON(body, auto_unbox = TRUE), "application/json")
   } else if (encode == "multipart") {

--- a/R/url-query.r
+++ b/R/url-query.r
@@ -7,23 +7,27 @@ parse_query <- function(query) {
   values
 }
 
-compose_query <- function(elements) {
+compose_query <- function(elements, part = c("query", "other")) {
   if (length(elements) == 0)
     return("")
 
   if (!all(has_name(elements)))
     stop("All components of query must be named", call. = FALSE)
 
+  part <- match.arg(part)
+
   stopifnot(is.list(elements))
   elements <- compact(elements)
 
   names <- curl::curl_escape(names(elements))
 
-  encode <- function(x) {
+  encode <- function(x, part) {
     if (inherits(x, "AsIs")) return(x)
-    curl::curl_escape(x)
+    switch(part,
+           query = URLencode(enc2utf8(as.character(x))),
+           other = curl::curl_escape(x))
   }
-  values <- vapply(elements, encode, character(1))
+  values <- vapply(elements, encode, character(1), part = part)
 
   paste0(names, "=", values, collapse = "&")
 }

--- a/tests/testthat/test-url.r
+++ b/tests/testthat/test-url.r
@@ -86,3 +86,9 @@ test_that("I() prevents escaping", {
 test_that("null elements are dropped", {
   expect_equal(compose_query(list(x = 1, y = NULL)), "x=1")
 })
+
+# https://github.com/hadley/httr/issues/335
+test_that("'+' becomes '%20' in the query part", {
+  url <- "http://google.com/?q=saint+paul+mn"
+  expect_equal(url, build_url(parse_url(url)))
+})


### PR DESCRIPTION
Not sure this is the best solution. But it confirms the query needs to be encoded differently than other parts of the URL. It rescues my example from #335.

``` r
library(httr)

query_space <- "type:issue author:hadley repo:rstudio/rstudioapi state:open"
query_plus <- "type:issue+author:hadley+repo:rstudio/rstudioapi+state:open"
list_space <- list(q = query_space)
list_plus <- list(q = query_plus)

(url <-
  modify_url("https://api.github.com", path = "search/issues", query = list_space))
#> [1] "https://api.github.com/search/issues?q=type:issue%20author:hadley%20repo:rstudio/rstudioapi%20state:open"
status_code(x <- GET(url))
#> [1] 200

(url <-
  modify_url("https://api.github.com", path = "search/issues", query = list_plus))
#> [1] "https://api.github.com/search/issues?q=type:issue+author:hadley+repo:rstudio/rstudioapi+state:open"
status_code(x <- GET(url))
#> [1] 200
```