### PR TITLE
Expose na parameter of jsonlite::toJSON in PATCH, POST, PUT and VERB

### DIFF
--- a/R/body.R
+++ b/R/body.R
@@ -1,4 +1,4 @@
-body_config <- function(body = NULL, encode = "form", type = NULL)  {
+body_config <- function(body = NULL, encode = "form", type = NULL, json.NA = c("null", "string"))  {
   # No body
   if (identical(body, FALSE))
     return(config(post = TRUE, nobody = TRUE))
@@ -42,7 +42,7 @@ body_config <- function(body = NULL, encode = "form", type = NULL)  {
   if (encode == "form") {
     body_raw(compose_query(body), "application/x-www-form-urlencoded")
   } else if (encode == "json") {
-    body_raw(jsonlite::toJSON(body, auto_unbox = TRUE), "application/json")
+    body_raw(jsonlite::toJSON(body, auto_unbox = TRUE, na = JSON.na), "application/json")
   } else if (encode == "multipart") {
     if (!all(has_name(body)))
       stop("All components of body must be named", call. = FALSE)

--- a/R/body.R
+++ b/R/body.R
@@ -42,7 +42,7 @@ body_config <- function(body = NULL, encode = "form", type = NULL, json.NA = c("
   if (encode == "form") {
     body_raw(compose_query(body), "application/x-www-form-urlencoded")
   } else if (encode == "json") {
-    body_raw(jsonlite::toJSON(body, auto_unbox = TRUE, na = JSON.na), "application/json")
+    body_raw(jsonlite::toJSON(body, auto_unbox = TRUE, na = json.NA), "application/json")
   } else if (encode == "multipart") {
     if (!all(has_name(body)))
       stop("All components of body must be named", call. = FALSE)

--- a/R/http-patch.r
+++ b/R/http-patch.r
@@ -6,7 +6,8 @@
 #' @export
 PATCH <- function(url = NULL, config = list(), ..., body = NULL,
                   encode = c("multipart", "form", "json"),
-                  multipart = TRUE, handle = NULL) {
+                  multipart = TRUE, handle = NULL,
+                  json.NA = c("null", "string")) {
 
   if (!missing(multipart)) {
     warning("multipart is deprecated, please use encode argument instead",
@@ -16,6 +17,6 @@ PATCH <- function(url = NULL, config = list(), ..., body = NULL,
   encode <- match.arg(encode)
 
   hu <- handle_url(handle, url, ...)
-  req <- request_build("PATCH", hu$url, body_config(body, encode), config, ...)
+  req <- request_build("PATCH", hu$url, body_config(body, encode, json.NA = json.NA), config, ...)
   request_perform(req, hu$handle$handle)
 }

--- a/R/http-post.r
+++ b/R/http-post.r
@@ -42,7 +42,8 @@
 #' POST(b2, body = "", verbose())
 POST <- function(url = NULL, config = list(), ..., body = NULL,
                  encode = c("multipart", "form", "json"),
-                 multipart = TRUE, handle = NULL) {
+                 multipart = TRUE, handle = NULL,
+                 json.NA = c("null", "string")) {
   if (!missing(multipart)) {
     warning("multipart is deprecated, please use encode argument instead",
       call. = FALSE)
@@ -51,6 +52,6 @@ POST <- function(url = NULL, config = list(), ..., body = NULL,
   encode <- match.arg(encode)
 
   hu <- handle_url(handle, url, ...)
-  req <- request_build("POST", hu$url, body_config(body, encode), config, ...)
+  req <- request_build("POST", hu$url, body_config(body, encode, json.NA = json.NA), config, ...)
   request_perform(req, hu$handle$handle)
 }

--- a/R/http-post.r
+++ b/R/http-post.r
@@ -28,7 +28,7 @@
 #'   \code{FALSE} = {encode = "form"}.
 #'   Files can not be uploaded when \code{FALSE}.
 #' @param json.NA When encoding to JSON, this parameter tells the jsonlite
-#'   package how to handle NA values. Must be "string" or "null"
+#'   package how to handle NA values. Must be "string" or "null".
 #' @export
 #' @family http methods
 #' @examples

--- a/R/http-post.r
+++ b/R/http-post.r
@@ -27,6 +27,8 @@
 #' @param multipart Deprecated. \code{TRUE} = \code{encode = "multipart"},
 #'   \code{FALSE} = {encode = "form"}.
 #'   Files can not be uploaded when \code{FALSE}.
+#' @param json.NA When encoding to JSON, this parameter tells the jsonlite
+#'   package how to handle NA values. Must be "string" or "null"
 #' @export
 #' @family http methods
 #' @examples

--- a/R/http-put.r
+++ b/R/http-put.r
@@ -14,7 +14,8 @@
 #' PUT(b2, body = list(x = "A simple text string"), encode = "json")
 PUT <- function(url = NULL, config = list(), ..., body = NULL,
                   encode = c("multipart", "form", "json"),
-                  multipart = TRUE, handle = NULL) {
+                  multipart = TRUE, handle = NULL,
+                json.NA = c("null", "string")) {
   if (!missing(multipart)) {
     warning("multipart is deprecated, please use encode argument instead",
       call. = FALSE)
@@ -23,6 +24,6 @@ PUT <- function(url = NULL, config = list(), ..., body = NULL,
   encode <- match.arg(encode)
 
   hu <- handle_url(handle, url, ...)
-  req <- request_build("PUT", hu$url, body_config(body, encode), config, ...)
+  req <- request_build("PUT", hu$url, body_config(body, encode, json.NA = json.NA), config, ...)
   request_perform(req, hu$handle$handle)
 }

--- a/R/http-verb.R
+++ b/R/http-verb.R
@@ -16,11 +16,12 @@
 #' VERB("POST", url = "http://httpbin.org/post")
 #' VERB("POST", url = "http://httpbin.org/post", body = "foobar")
 VERB <- function(verb, url = NULL, config = list(), ..., body = NULL,
-                 encode = c("multipart", "form", "json"), handle = NULL) {
+                 encode = c("multipart", "form", "json"), handle = NULL,
+                 json.NA = c("null", "string")) {
 
   encode <- match.arg(encode)
 
   hu <- handle_url(handle, url, ...)
-  req <- request_build(verb, hu$url, body_config(body, encode), config, ...)
+  req <- request_build(verb, hu$url, body_config(body, encode, json.NA = json.NA), config, ...)
   request_perform(req, hu$handle$handle)
 }

--- a/man/PATCH.Rd
+++ b/man/PATCH.Rd
@@ -6,7 +6,7 @@
 \usage{
 PATCH(url = NULL, config = list(), ..., body = NULL,
   encode = c("multipart", "form", "json"), multipart = TRUE,
-  handle = NULL)
+  handle = NULL, json.NA = c("null", "string"))
 }
 \arguments{
 \item{url}{the url of the page to retrieve}
@@ -56,6 +56,9 @@ requests to the same scheme/host/port combo. This substantially reduces
 connection time, and ensures that cookies are maintained over multiple
 requests to the same host. See \code{\link{handle_pool}} for more
 details.}
+
+\item{json.NA}{When encoding to JSON, this parameter tells the jsonlite
+package how to handle NA values. Must be "string" or "null".}
 }
 \description{
 Send PATCH request to a server.

--- a/man/POST.Rd
+++ b/man/POST.Rd
@@ -6,7 +6,7 @@
 \usage{
 POST(url = NULL, config = list(), ..., body = NULL,
   encode = c("multipart", "form", "json"), multipart = TRUE,
-  handle = NULL)
+  handle = NULL, json.NA = c("null", "string"))
 }
 \arguments{
 \item{url}{the url of the page to retrieve}
@@ -56,6 +56,9 @@ requests to the same scheme/host/port combo. This substantially reduces
 connection time, and ensures that cookies are maintained over multiple
 requests to the same host. See \code{\link{handle_pool}} for more
 details.}
+
+\item{json.NA}{When encoding to JSON, this parameter tells the jsonlite
+package how to handle NA values. Must be "string" or "null".}
 }
 \description{
 POST file to a server.

--- a/man/PUT.Rd
+++ b/man/PUT.Rd
@@ -6,7 +6,7 @@
 \usage{
 PUT(url = NULL, config = list(), ..., body = NULL,
   encode = c("multipart", "form", "json"), multipart = TRUE,
-  handle = NULL)
+  handle = NULL, json.NA = c("null", "string"))
 }
 \arguments{
 \item{url}{the url of the page to retrieve}
@@ -56,6 +56,9 @@ requests to the same scheme/host/port combo. This substantially reduces
 connection time, and ensures that cookies are maintained over multiple
 requests to the same host. See \code{\link{handle_pool}} for more
 details.}
+
+\item{json.NA}{When encoding to JSON, this parameter tells the jsonlite
+package how to handle NA values. Must be "string" or "null".}
 }
 \description{
 Send PUT request to server.

--- a/man/VERB.Rd
+++ b/man/VERB.Rd
@@ -5,7 +5,8 @@
 \title{VERB a url.}
 \usage{
 VERB(verb, url = NULL, config = list(), ..., body = NULL,
-  encode = c("multipart", "form", "json"), handle = NULL)
+  encode = c("multipart", "form", "json"), handle = NULL,
+  json.NA = c("null", "string"))
 }
 \arguments{
 \item{verb}{Name of verb to use.}
@@ -53,6 +54,9 @@ requests to the same scheme/host/port combo. This substantially reduces
 connection time, and ensures that cookies are maintained over multiple
 requests to the same host. See \code{\link{handle_pool}} for more
 details.}
+
+\item{json.NA}{When encoding to JSON, this parameter tells the jsonlite
+package how to handle NA values. Must be "string" or "null".}
 }
 \description{
 Use an arbitrary verb.


### PR DESCRIPTION
This helps the package to cover some more use cases. Since the default value stays the same, there should not arise any issues.

Now the parameter `json.NA` may be specified when calling `PATCH`, `POST`, `PUT` or `VERB`. The parameter must be `"null"` or `"string"`. The default is `c("null", "string")`. Example:
```
result = httr::POST(url, body=content, encode = "json", 
  					json.NA = "null")
```