### PR TITLE
enh: use the appropriate CURL options for specifying methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # httr 1.1.0.9000
 
+* Don't use custom requests anymore for standard `POST`, `GET` and `PUT` requests
+  (issue #356, fix #357). This has the side-effect of properly following redirects
+  after `POST`, fixing usual login issues (eg hadley/rvest#133).
+
 * New `http_type()` returns the content/mime type of a request, sans parameters.
 
 * Fix in readfunction to close connection when done.

--- a/R/request.R
+++ b/R/request.R
@@ -99,7 +99,14 @@ print.request <- function(x, ...) {
 
 request_prepare <- function(req) {
   req <- request_combine(request_default(), req)
-  req$options$customrequest <- req$method
+  switch(req$method,
+         "POST" = {
+           req$options$post <- TRUE},
+         "PUT" = {
+           req$options$put <- TRUE},
+         "GET" = {
+           req$options$httpget <- TRUE},
+         {req$options$customrequest <- req$method})
 
   # Sign request, if needed
   token <- req$auth_token

--- a/R/request.R
+++ b/R/request.R
@@ -99,13 +99,13 @@ print.request <- function(x, ...) {
 
 request_prepare <- function(req) {
   req <- request_combine(request_default(), req)
+
+  # Use the appropriate cURL method when available.
+  # This - among others - ensures proper behaviour on redirects.
   switch(req$method,
-         "POST" = {
-           req$options$post <- TRUE},
-         "PUT" = {
-           req$options$put <- TRUE},
-         "GET" = {
-           req$options$httpget <- TRUE},
+         "POST" = {req$options$post <- TRUE},
+         "PUT" = {req$options$put <- TRUE},
+         "GET" = {req$options$httpget <- TRUE},
          {req$options$customrequest <- req$method})
 
   # Sign request, if needed


### PR DESCRIPTION
cf #356.
A small fix can go a long way :-). I'd advocate for quick publishing to CRAN after inclusion of this PR (or whatever other code change that solves #356).