### PR TITLE
Allow to easily customize number of digits for JSON serialization

### DIFF
--- a/R/body.R
+++ b/R/body.R
@@ -46,7 +46,7 @@ body_config <- function(body = NULL, encode = "form", type = NULL)  {
   if (encode == "form") {
     body_raw(compose_query(body), "application/x-www-form-urlencoded")
   } else if (encode == "json") {
-    body_raw(jsonlite::toJSON(body, auto_unbox = TRUE), "application/json")
+    body_raw(jsonlite::toJSON(body, auto_unbox = TRUE, digits = getOption('httr.digits', 4), "application/json")
   } else if (encode == "multipart") {
     if (!all(has_name(body)))
       stop("All components of body must be named", call. = FALSE)

--- a/R/body.R
+++ b/R/body.R
@@ -46,7 +46,7 @@ body_config <- function(body = NULL, encode = "form", type = NULL)  {
   if (encode == "form") {
     body_raw(compose_query(body), "application/x-www-form-urlencoded")
   } else if (encode == "json") {
-    body_raw(jsonlite::toJSON(body, auto_unbox = TRUE, digits = getOption('httr.digits', 4), "application/json")
+    body_raw(jsonlite::toJSON(body, auto_unbox = TRUE, digits = getOption("httr.digits", 4)), "application/json")
   } else if (encode == "multipart") {
     if (!all(has_name(body)))
       stop("All components of body must be named", call. = FALSE)


### PR DESCRIPTION
by setting `options(httr.digits = desired_number_of_digits)`