### PR TITLE
Do not prepend oauth_ to additional parameters for oauth_signature

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## New features
 
+* `oauth_signature()` no longer prepends 'oauth\_'  to additional parameters.
+  (@jimhester, #373)
+
 * All `print()` methods now invisibly return `x` (#355).
 
 * `DELETE()` gains a body parameter (#326).

--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -16,8 +16,8 @@ init_oauth1.0 <- function(endpoint, app, permission = NULL,
                           private_key = NULL) {
 
   oauth_sig <- function(url, method, token = NULL, token_secret = NULL, private_key = NULL, ...) {
-    oauth_header(oauth_signature(url, method, app, token, token_secret, private_key, ...,
-      callback = oauth_callback()))
+    oauth_header(oauth_signature(url, method, app, token, token_secret, private_key,
+        other_params = c(list(...), oauth_callback = oauth_callback())))
   }
 
   # 1. Get an unauthorized request token
@@ -31,11 +31,11 @@ init_oauth1.0 <- function(endpoint, app, permission = NULL,
   authorize_url <- modify_url(endpoint$authorize, query = list(
     oauth_token = token,
     permission = "read"))
-  verifier <- oauth_listener(authorize_url, is_interactive)[[1]]
+  verifier <- oauth_listener(authorize_url, is_interactive)$oauth_verifier
 
   # 3. Request access token
   response <- POST(endpoint$access,
-    oauth_sig(endpoint$access, "POST", token, secret, verifier = verifier, private_key = private_key),
+    oauth_sig(endpoint$access, "POST", token, secret, oauth_verifier = verifier, private_key = private_key),
     body = ""
   )
   stop_for_status(response)

--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -31,7 +31,8 @@ init_oauth1.0 <- function(endpoint, app, permission = NULL,
   authorize_url <- modify_url(endpoint$authorize, query = list(
     oauth_token = token,
     permission = "read"))
-  verifier <- oauth_listener(authorize_url, is_interactive)$oauth_verifier
+  verifier <- oauth_listener(authorize_url, is_interactive)
+  verifier <- verifier$oauth_verifier %||% verifier[[1]]
 
   # 3. Request access token
   response <- POST(endpoint$access,

--- a/R/oauth-signature.r
+++ b/R/oauth-signature.r
@@ -33,15 +33,14 @@ sign_oauth2.0 <- function(access_token, as_header = TRUE) {
 #' @param url,method Url and http method of request.
 #' @param app \code{\link{oauth_app}} object representing application.
 #' @param token,token_secret OAuth token and secret.
-#' @param ... Named argument providing additional oauth parameters
-#'   (e.g. \code{oauth_callback} or \code{oauth_body_hash}). Names should
-#'   not include the "oauth_" prefix - this will be automatically included.
+#' @param other_params Named argument providing additional parameters
+#'   (e.g. \code{oauth_callback} or \code{oauth_body_hash}).
 #' @export
 #' @keywords internal
 #' @return A list of oauth parameters.
 oauth_signature <- function(url, method = "GET", app, token = NULL,
                             token_secret = NULL,
-                            private_key = NULL, ...) {
+                            private_key = NULL, other_params = NULL) {
   if (!is.null(private_key)) {
     signature_method <- "RSA-SHA1"
   } else {
@@ -61,9 +60,7 @@ oauth_signature <- function(url, method = "GET", app, token = NULL,
     oauth_token = token
   ))
 
-  other_params <- list(...)
   if (length(other_params) > 0) {
-    names(other_params) <- paste0("oauth_", names(other_params))
     oauth <- c(oauth, other_params)
   }
 

--- a/man/oauth_signature.Rd
+++ b/man/oauth_signature.Rd
@@ -6,7 +6,7 @@
 \title{Generate oauth signature.}
 \usage{
 oauth_signature(url, method = "GET", app, token = NULL,
-  token_secret = NULL, private_key = NULL, ...)
+  token_secret = NULL, private_key = NULL, other_params = NULL)
 
 oauth_header(info)
 }
@@ -17,9 +17,8 @@ oauth_header(info)
 
 \item{token, token_secret}{OAuth token and secret.}
 
-\item{...}{Named argument providing additional oauth parameters
-(e.g. \code{oauth_callback} or \code{oauth_body_hash}). Names should
-not include the "oauth_" prefix - this will be automatically included.}
+\item{other_params}{Named argument providing additional parameters
+(e.g. \code{oauth_callback} or \code{oauth_body_hash}).}
 }
 \value{
 A list of oauth parameters.


### PR DESCRIPTION
The flickr API for instance needs all query parameters to be included in
the signature. (https://www.flickr.com/services/api/auth.oauth.html#yui_3_11_0_1_1464787470505_317)

With this change I am able to get a 200 response with the following code (app secret redacted)

```r
f <- oauth_app("r to flickr", "ed724990662ac2b8c236726a34226ea9", "<redacted>")

ep <- oauth_endpoint(
  request = "https://www.flickr.com/services/oauth/request_token",
  authorize = "https://www.flickr.com/services/oauth/authorize",
  access = "https://www.flickr.com/services/oauth/access_token"
)

tok <- oauth1.0_token(ep, f, cache = T)

signature <- oauth_signature("https://api.flickr.com/services/rest", app =
  tok$app, token = tok$credentials$oauth_token, token_secret =
  tok$credentials$oauth_token_secret,
  other_params = list(method = "flickr.test.login", format = "json", "nojsoncallback" = 1))

GET("https://api.flickr.com/services/rest", query = signature)
```