### PR TITLE
fix typo

### DIFF
--- a/vignettes/api-packages.Rmd
+++ b/vignettes/api-packages.Rmd
@@ -420,7 +420,7 @@ rate_limit <- function() {
 rate_limit()
 ```
 
-## Packaging youe code
+## Packaging your code
 
 ### Documentation
 


### PR DESCRIPTION
`youe code` to `your code`