### PR TITLE
Expand git and Rbuild ignoring of newly created oauth cache files; fixes #436

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr 1.2.1.9000
 
+* New oauth cache files are always added to `.gitignore` and, if it exists, `.Rbuildignore`. Specifically, this now happens when option `httr_oauth_cache = TRUE` or user specifies cache file name explicitly. (@jennybc #436)
+
 * New functions `set_callback()` and `get_callback()` set and query
   callback functions that are called right before and after performing an
   HTTP request (@gaborcsardi #409)

--- a/R/oauth-cache.R
+++ b/R/oauth-cache.R
@@ -6,21 +6,30 @@ use_cache <- function(cache = getOption("httr_oauth_cache")) {
     stop("Cache must either be logical or string (file path)")
   }
 
-  # If it's a character, then it's a file path, so use it
-  if (is.character(cache)) return(cache)
-
   # If missing, see if it's ok to use one, and cache the results of
   # that check in a global option.
   if (is.na(cache)) {
     cache <- can_use_cache()
     options("httr_oauth_cache" = cache)
   }
+  ## cache is now TRUE, FALSE or path
 
-  if (cache) ".httr-oauth" else NULL
+  if (isFALSE(cache)) {
+    return(NULL)
+  }
+
+  if (isTRUE(cache)) {
+    cache <- ".httr-oauth"
+  }
+
+  if (!file.exists(cache)) {
+    create_cache(cache)
+  }
+  return(cache)
 }
 
 can_use_cache <- function(path = ".httr-oauth") {
-  file.exists(path) || (should_cache(path) && create_cache(path))
+  file.exists(path) || should_cache(path)
 }
 
 should_cache <- function(path = ".httr-oauth") {

--- a/R/utils.r
+++ b/R/utils.r
@@ -84,3 +84,5 @@ find_cert_bundle <- function() {
   # Fall back to certificate bundle in openssl
   system.file("cacert.pem", package = "openssl")
 }
+
+isFALSE <- function(x) identical(x, FALSE)

--- a/tests/testthat/test-oauth-cache.R
+++ b/tests/testthat/test-oauth-cache.R
@@ -57,15 +57,14 @@ test_that("token saved to and restored from cache", {
 test_that("new caches are Rbuildignored and gitignored", {
   owd <- setwd(tmp_dir())
   on.exit(setwd(owd))
-  old <- options()
-  on.exit(options(old), add = TRUE)
   file.create("DESCRIPTION")
 
   ## default: options("httr_oauth_cache" = NA)
   ## not tested
   ## if cache does not exist, will not be created if !interactive()
 
-  options("httr_oauth_cache" = TRUE)
+  old <- options("httr_oauth_cache" = TRUE)
+  on.exit(options(old), add = TRUE)
   use_cache()
   expect_true(file.exists(".Rbuildignore"))
   expect_identical(readLines(".Rbuildignore"), "^\\.httr-oauth$")

--- a/tests/testthat/test-oauth-cache.R
+++ b/tests/testthat/test-oauth-cache.R
@@ -1,6 +1,17 @@
 context("OAuth cache")
 
+tmp_dir <- function() {
+  x <- tempfile()
+  dir.create(x)
+  x
+}
+
 test_that("use_cache() returns NULL or filepath", {
+  old <- options()
+  on.exit(options(old))
+  owd <- setwd(tmp_dir())
+  on.exit(setwd(owd), add = TRUE)
+
   expect_equal(use_cache(FALSE), NULL)
   expect_equal(use_cache(TRUE), ".httr-oauth")
   expect_equal(use_cache("xyz"), "xyz")
@@ -9,6 +20,8 @@ test_that("use_cache() returns NULL or filepath", {
 test_that("use_cache() respects options", {
   old <- options()
   on.exit(options(old))
+  owd <- setwd(tmp_dir())
+  on.exit(setwd(owd), add = TRUE)
 
   options(httr_oauth_cache = FALSE)
   expect_equal(use_cache(), NULL)
@@ -18,7 +31,8 @@ test_that("use_cache() respects options", {
 })
 
 test_that("token saved to and restored from cache", {
-  on.exit(unlink(".tmp-cache"))
+  owd <- setwd(tmp_dir())
+  on.exit(setwd(owd))
 
   token_a <- Token2.0$new(
     app = oauth_app("x", "y", "z"),

--- a/tests/testthat/test-oauth-cache.R
+++ b/tests/testthat/test-oauth-cache.R
@@ -53,3 +53,30 @@ test_that("token saved to and restored from cache", {
   expect_equal(token_b$endpoint, token_a$endpoint)
   expect_equal(token_b$credentials, token_a$credentials)
 })
+
+test_that("new caches are Rbuildignored and gitignored", {
+  owd <- setwd(tmp_dir())
+  on.exit(setwd(owd))
+  old <- options()
+  on.exit(options(old), add = TRUE)
+  file.create("DESCRIPTION")
+
+  ## default: options("httr_oauth_cache" = NA)
+  ## not tested
+  ## if cache does not exist, will not be created if !interactive()
+
+  options("httr_oauth_cache" = TRUE)
+  use_cache()
+  expect_true(file.exists(".Rbuildignore"))
+  expect_identical(readLines(".Rbuildignore"), "^\\.httr-oauth$")
+  expect_true(file.exists(".gitignore"))
+  expect_identical(readLines(".gitignore"), ".httr-oauth")
+
+  unlink(c(".httr-oauth", ".Rbuildignore", ".gitignore"))
+
+  use_cache("xyz")
+  expect_true(file.exists(".Rbuildignore"))
+  expect_identical(readLines(".Rbuildignore"), "^xyz$")
+  expect_true(file.exists(".gitignore"))
+  expect_identical(readLines(".gitignore"), "xyz")
+})


### PR DESCRIPTION
Fixes #436

httr is only adding a new cache file to `.gitignore` and `.Rbuildignore` in the case of `cache = NA`. This PR makes it do so when `cache = TRUE` and when `cache` holds a path.

I am doing each test re: oauth caching in a fresh temp directory because behaviour is affected by which files already exist and it's unsettling to have code like `unlink(".gitignore")`. I also save and restore options in these tests, because `use_cache()` potentially changes the value of `httr_oauth_cache`.