### PR TITLE
Tighten 'verb' description

### DIFF
--- a/R/http-verb.R
+++ b/R/http-verb.R
@@ -4,7 +4,7 @@
 #'
 #' @inherit GET params return
 #' @inheritParams POST
-#' @param verb Name of verb to use.
+#' @param verb Character string naming the verb to use.
 #' @family http methods
 #' @export
 #' @examples

--- a/man/RETRY.Rd
+++ b/man/RETRY.Rd
@@ -22,7 +22,7 @@ RETRY(
 )
 }
 \arguments{
-\item{verb}{Name of verb to use.}
+\item{verb}{Character string naming the verb to use.}
 
 \item{url}{the url of the page to retrieve}
 

--- a/man/VERB.Rd
+++ b/man/VERB.Rd
@@ -15,7 +15,7 @@ VERB(
 )
 }
 \arguments{
-\item{verb}{Name of verb to use.}
+\item{verb}{Character string naming the verb to use.}
 
 \item{url}{the url of the page to retrieve}
 


### PR DESCRIPTION
It wasn't immediately clear to me in `?RETRY` whether `RETRY(GET, ...)` would work. `is.name(GET)` is `TRUE` in R, after all.