### PR TITLE
Workaround for FTP crashes in some libcurl versions

### DIFF
--- a/R/handle-pool.r
+++ b/R/handle-pool.r
@@ -21,7 +21,10 @@ handle_find <- function(url) {
     handle <- handle_pool[[name]]
   } else {
     handle <- handle(name)
-    handle_pool[[name]] <- handle
+    # Pool http requests only: https://github.com/curl/curl/issues/13731
+    if (grepl('^http', name)) {
+      handle_pool[[name]] <- handle
+    }
   }
 
   handle


### PR DESCRIPTION
There is [a bug](https://github.com/curl/curl/issues/13731) in libcurl 8.5.0 - 8.7.1 that causes a crash if you mix http and ftp requests in the same handle. Unfortunately these versions of libcurl are common on both Linux and MacOS.

A reprex that crashes both on Ubuntu 24.04 and all current MacOS versions:

```r
library(httr)
url1 <- "https://en.wikipedia.org/wiki/Bioconductor"
response1 <- GET(url1)
url2 <- "ftp://ftp.ensembl.org/pub/release-71/gtf/caenorhabditis_elegans/Caenorhabditis_elegans.WBcel235.71.gtf.gz"
response2a <- GET(url2, write_disk(tempfile()))
response2b <- GET(url2, write_disk(tempfile()))
```

Pooling handles is a legacy feature that is not recommended anymore. The only use is sharing cookies between requests. However FTP requests don't have cookies, so it makes no sense to pool the handle. A straightforward fix therefore is to only pool handles for http requests.

Even though httr is not intended for FTP and not actively maintained, I still think we should push this fix.