### PR TITLE
fix broken URL from pkgdown site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -78,4 +78,4 @@ reference:
 news:
   releases:
   - text: "Version 1.4.0"
-    href: https://www.tidyverse.org/articles/2018/12/httr-1-4-0/
+    href: https://www.tidyverse.org/blog/2018/12/httr-1-4-0/


### PR DESCRIPTION
The link in the News dropdown currently goes to a broken link